### PR TITLE
Fixing bad implementation of Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ do GitHub.
 
         $ mvn cobertura:cobertura
 
-Aonde o HTML resultante está localizado em:
+Onde o HTML resultante está localizado em:
 
 * target/site/cobertura/index.html (pra Unix)
 * target\site\cobertura\index.html (pra Windows)


### PR DESCRIPTION
According to the official specs, and I quote:

> O advérbio “onde” é utilizado quando nos referimos a um lugar de paragem e de permanência, onde algo/alguém está (Ex.: «Onde vive o João?») e o advérbio aonde é usado em situações que indicam o destino de um movimento, deslocação a um lugar («Aonde vais à noite?»).

<sub>@marcoonroad to com saudades_<sub>


Thank you


